### PR TITLE
get_csa_props: also accept "param    = 0x1" (Pitt 7T)

### DIFF
--- a/MRdataset/common_dicom.py
+++ b/MRdataset/common_dicom.py
@@ -337,12 +337,40 @@ def csa_parser(dicom):
 
 
 def get_csa_props(parameter, corpus):
+    """Extract parameter code from CSA header text
+
+    we want 0x1 from e.g.
+    sAdjData.uiAdjShimMode                = 0x1
+    """
     index = corpus.find(parameter)
     if index == -1:
         return -1
+
     shift = len(parameter)+6
-    code = re.split('\t|\n', corpus[index:index + shift])[2]
-    return code
+    if index + shift > len(corpus):
+        print(f"#WARNING: {parameter} in CSA too short: '{corpus[index:]}'")
+        return -1
+
+    # 6 chars after parameter text, 3rd value
+    param_val = corpus[index:index + shift]
+    code_parts = re.split('\t|\n', param_val)
+    if len(code_parts) >= 3:
+        return code_parts[2]
+
+    # if not above, might look like:
+    # sAdjData.uiAdjShimMode                = 0x1
+
+    # this runs multiple times on every dicom
+    # regexp is expesive? dont use unless we need to
+    match = re.search('=\s*(.*)(\n|$)', corpus[index:])
+    if match:
+        match = match.groups()[0]
+        # above is also a string. dont worry about conversion?
+        # match = int(match, 0)  # 0x1 -> 1
+        return match
+
+    # couldn't figure out
+    return -1
 
 
 def effective_echo_spacing(dicom):

--- a/MRdataset/common_dicom.py
+++ b/MRdataset/common_dicom.py
@@ -362,7 +362,7 @@ def get_csa_props(parameter, corpus):
 
     # this runs multiple times on every dicom
     # regexp is expesive? dont use unless we need to
-    match = re.search('=\s*(.*)(\n|$)', corpus[index:])
+    match = re.search('=\s*([^\n]+)', corpus[index:])
     if match:
         match = match.groups()[0]
         # above is also a string. dont worry about conversion?

--- a/MRdataset/tests/test_MRdataset.py
+++ b/MRdataset/tests/test_MRdataset.py
@@ -7,6 +7,7 @@ import shutil
 import hypothesis.strategies as st
 from MRdataset import import_dataset
 from MRdataset.simulate import make_compliant_test_dataset
+from MRdataset.common_dicom import get_csa_props
 from hypothesis import given, settings
 
 
@@ -42,3 +43,10 @@ def test_parse_compliant_dataset(num_subjects,
     assert len(mrd_num_subjects) == num_subjects
     shutil.rmtree(fake_ds_dir)
     return
+
+
+def get_csa_props_test():
+    "CSA header looks funny in Pitt 7T (20221130)"
+    text = "blah = 0x1\nxy\nsAdjData.uiAdjShimMode                = 0x1\na = b"
+    shim_code = get_csa_props("sAdjData.uiAdjShimMode", text)
+    assert shim_code == '0x1'


### PR DESCRIPTION
At least some of Pitt's 7T dicom CSA headers don't match the mold. `get_csa_props` threw index range b/c there were not 3 tab sep values within the 6 characters after parameter (?)

printing `corpus` to debug, looks like
```
sAdjData.uiAdjShimMode                     = 0x1
sAdjData.uiAdjWatSupMode                 = 0x1
sAdjData.uiAdjRFMapMode                  = 0x1
```

So if the first pass fails, it'll now try a regexp. I'm not sure if it should also try to covert hex to int. (Or if it's doing the right thing to start with :) )